### PR TITLE
feat!: make label names clearer + add source node label

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -24,6 +24,11 @@ spec:
       containers:
         - name: cnetmon
           image: ctlptl-registry:5005/my-image
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           resources:
             limits:
               memory: 1024Mi

--- a/src/generic_client/generic_client.go
+++ b/src/generic_client/generic_client.go
@@ -5,9 +5,11 @@ import (
 	"cnetmon/structs"
 	"sync"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func Connect(outsideAddresses *[]structs.Target, mutex *sync.Mutex, m *metrics.Metrics, labels []string, function func(structs.Target, *metrics.Metrics, []string, *sync.WaitGroup)) {
+func Connect(outsideAddresses *[]structs.Target, mutex *sync.Mutex, m *metrics.Metrics, labels prometheus.Labels, function func(structs.Target, *metrics.Metrics, prometheus.Labels, *sync.WaitGroup)) {
 
 	for {
 		// be ultra-cautious here so we are 100% sure the slice isn't just updated.

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -37,17 +37,17 @@ func NewMetrics() *Metrics {
 			Help:    "Time the connect check takes",
 			Buckets: prometheus.ExponentialBuckets(0.125, 2, 16),
 		},
-			[]string{"protocol", "mode", "node_name", "pod_ip"},
+			[]string{"protocol", "mode", "src_node", "dst_node", "dst_pod_ip"},
 		),
 		PersistentLifetime: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cnetmon_persistent_connection_lifetime",
 			Help: "Time in seconds a persistent connection is open",
-		}, []string{"direction", "node_name", "pod_ip"}),
+		}, []string{"direction", "src_node", "dst_node", "dst_pod_ip"}),
 		PingTiming: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cnetmon_ping_timing_milliseconds",
 			Help:    "Time in ms it takes to reply to a ping on a persistent TCP connection",
 			Buckets: prometheus.ExponentialBuckets(0.0125, 2, 18),
-		}, []string{"node_name", "pod_ip"}),
+		}, []string{"src_node", "dst_node", "dst_pod_ip"}),
 	}
 	return m
 }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"cnetmon/structs"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
 
@@ -30,4 +31,17 @@ func IPTargetInSlice(a structs.Target, list []structs.Target) bool {
 		}
 	}
 	return false
+}
+
+func Merge(labels1 prometheus.Labels, labels2 prometheus.Labels) prometheus.Labels {
+	result := prometheus.Labels{}
+
+	for k, v := range labels1 {
+		result[k] = v
+	}
+	for k, v := range labels2 {
+		result[k] = v
+	}
+
+	return result
 }


### PR DESCRIPTION
This PR changes existing Prometheus metric labels to avoid confusion (e.g., `dst_node` instead of `node_name`) and adds a `src_node` label. It also fixes a bug in which the values for the `mode` and `protocol` labels were swapped, resulting, for instance, in `protocol="k8s"` instead of `protocol="tcp"`.