### PR TITLE
feat!: emit +Inf when test fails

### DIFF
--- a/src/tcp/client.go
+++ b/src/tcp/client.go
@@ -4,6 +4,7 @@ import (
 	"cnetmon/metrics"
 	"cnetmon/structs"
 	"cnetmon/utils"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -21,12 +22,15 @@ func Connect(target structs.Target, m *metrics.Metrics, labels prometheus.Labels
 		return
 	}
 
+	metric := m.Timing.With(utils.Merge(labels, prometheus.Labels{"dst_node": target.NodeName, "dst_pod_ip": tcpAddr.IP.String()}))
+
 	start := time.Now()
 	dialer := net.Dialer{Timeout: 2 * time.Second}
 	conn, err := dialer.Dial("tcp", target.IP+":7777")
 	if err != nil {
 
 		log.Error().Err(err).Msg("Can't connect")
+		metric.Observe(math.Inf(1))
 		return
 	}
 	conn.Write([]byte("ping"))
@@ -37,9 +41,10 @@ func Connect(target structs.Target, m *metrics.Metrics, labels prometheus.Labels
 	_, err = conn.Read(reply)
 	if err != nil {
 		log.Error().Err(err).Msg("Can't read reply")
+		metric.Observe(math.Inf(1))
 		return
 	}
-	m.Timing.With(utils.Merge(labels, prometheus.Labels{"dst_node": target.NodeName, "dst_pod_ip": tcpAddr.IP.String()})).Observe(float64(time.Since(start).Milliseconds()))
+	metric.Observe(float64(time.Since(start).Milliseconds()))
 
 	conn.Write([]byte("bye"))
 


### PR DESCRIPTION
Previously, when a TCP or UDP connection test failed (e.g., because it ran into a timeout), no data point would be recorded for the histogram. This PR changes this behavior, recording `+Inf` instead. This makes it easier to detect when networking is severely slowed down or broken in other ways.